### PR TITLE
Fixing Restart

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,9 +67,6 @@
     - Restart server following Docker changes
   when: docker.version != "latest"
 
-- name: Flush handlers to reboot immediately
-  meta: flush_handlers
-
 - name: Make certificate directories
   win_file:
     path: "{{ item }}"
@@ -141,8 +138,3 @@
   failed_when: firewall_res.rc == 2
   register: firewall_res
   when: setup_firewall_rules | bool
-
-- name: Make sure docker is started
-  win_service:
-    name: Docker
-    state: started


### PR DESCRIPTION
Previously, the restart handler for the role wasn't firing. This PR fixes this but now doesn't check that the installation was successful due to the way handlers work. I don't think this is worthwhile to have in the script since really such a thing should be tested using idempotency checks or separate infra testing scripts.